### PR TITLE
Update index.html consistently use https

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
 
 	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular.min.js"></script>
-	<script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.18/angular-ui-router.min.js"></script>
+	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.18/angular-ui-router.min.js"></script>
 	<script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js"></script>
 	<script type="text/javascript" src="app.js"></script>
 </body>


### PR DESCRIPTION
Load angular router with https like other script refs, so that it can be loaded from an app hosted on https, such as hosting the entire app in WCH CDN.